### PR TITLE
In Rpath vignette, added import row (all NA) to diet assignments

### DIFF
--- a/Rpath/vignettes/Rpath.Rmd
+++ b/Rpath/vignettes/Rpath.Rmd
@@ -231,7 +231,7 @@ You can also assign the entire diet composition for a predator:
 
 ```{r how to fill diet 2}
 whale.diet <- c(rep(NA, 3), 0.01, NA, 0.01, NA, 0.01, NA, 0.01, rep(NA, 4), 0.1,
-                rep(NA, 3), 0.86, rep(NA, 3))
+                rep(NA, 3), 0.86, rep(NA, 3), NA)
 REco.params$diet[, Whales := whale.diet]
 ```
 ```{r Dietfile table partial, echo = F}
@@ -242,48 +242,48 @@ Here is the completed model parameter file for R Ecosystem:
 
 ```{r diet fill}
 REco.params$diet[, Seabirds        := c(rep(NA, 11), 0.1, 0.25, 0.2, 0.15, 
-                                         rep(NA, 6), 0.3)]
+                                        rep(NA, 6), 0.3, NA)]
 REco.params$diet[, Whales          := c(rep(NA, 3), 0.01, NA, 0.01, NA, 0.01, 
-                                         NA, 0.01, rep(NA, 4), 0.1, rep(NA, 3), 
-                                         0.86, rep(NA, 3))]
+                                        NA, 0.01, rep(NA, 4), 0.1, rep(NA, 3), 
+                                        0.86, rep(NA, 3), NA)]
 REco.params$diet[, Seals           := c(rep(NA, 3), 0.05, 0.1, 0.05, 0.2, 0.005, 
-                                         0.05, 0.005, 0.01, 0.24, rep(0.05, 4), 
-                                         0.09, rep(NA, 5))]
+                                        0.05, 0.005, 0.01, 0.24, rep(0.05, 4), 
+                                        0.09, rep(NA, 5), NA)]
 REco.params$diet[, JuvRoundfish1   := c(rep(NA, 3), rep(c(1e-4, NA), 4), 1e-3, 
-                                         rep(NA, 2), 0.05, 1e-4, NA, .02, 0.7785, 
-                                         0.1, 0.05, NA)]
+                                        rep(NA, 2), 0.05, 1e-4, NA, .02, 0.7785, 
+                                        0.1, 0.05, NA, NA)]
 REco.params$diet[, AduRoundfish1   := c(rep(NA, 5), 1e-3, 0.01, 1e-3, 0.05, 1e-3, 
-                                         0.01, 0.29, 0.1, 0.1, 0.347, 0.03, NA, 
-                                         0.05, 0.01, rep(NA, 3))]
+                                        0.01, 0.29, 0.1, 0.1, 0.347, 0.03, NA, 
+                                        0.05, 0.01, rep(NA, 3), NA)]
 REco.params$diet[, JuvRoundfish2   := c(rep(NA, 3), rep(c(1e-4, NA), 4), 1e-3, 
-                                         rep(NA, 2), 0.05, 1e-4, NA, .02, 0.7785, 
-                                         0.1, .05, NA)]
+                                        rep(NA, 2), 0.05, 1e-4, NA, .02, 0.7785, 
+                                        0.1, .05, NA, NA)]
 REco.params$diet[, AduRoundfish2   := c(rep(NA, 3), 1e-4, NA, 1e-4, NA, rep(1e-4, 4), 
-                                         0.1, rep(0.05, 3), 0.2684, 0.01, 0.37, 0.001, 
-                                         NA, 0.1, NA)]
+                                        0.1, rep(0.05, 3), 0.2684, 0.01, 0.37, 0.001, 
+                                        NA, 0.1, NA, NA)]
 REco.params$diet[, JuvFlatfish1    := c(rep(NA, 3), rep(c(1e-4, NA), 4), rep(NA, 3), 
-                                         rep(1e-4, 2), NA, 0.416, 0.4334, 0.1, 0.05, 
-                                         NA)]
+                                        rep(1e-4, 2), NA, 0.416, 0.4334, 0.1, 0.05, 
+                                        NA, NA)]
 REco.params$diet[, AduFlatfish1    := c(rep(NA, 7), rep(1e-4, 5), rep(NA, 2), 0.001, 
-                                         0.05, 0.001, 0.6, 0.2475, NA, 0.1, NA)]
+                                        0.05, 0.001, 0.6, 0.2475, NA, 0.1, NA, NA)]
 REco.params$diet[, JuvFlatfish2    := c(rep(NA, 3), rep(c(1e-4, NA), 4), rep(NA, 3),
-                                         rep(1e-4, 2), NA, 0.416, 0.4334, 0.1, 0.05, 
-                                         NA)]
+                                        rep(1e-4, 2), NA, 0.416, 0.4334, 0.1, 0.05, 
+                                        NA, NA)]
 REco.params$diet[, AduFlatfish2    := c(rep(NA, 7), 1e-4, NA, 1e-4, rep(NA, 4), 
-                                         rep(1e-4, 3), 0.44, 0.3895, NA, 0.17, NA)]
+                                        rep(1e-4, 3), 0.44, 0.3895, NA, 0.17, NA, NA)]
 REco.params$diet[, OtherGroundfish := c(rep(NA, 3), rep(1e-4, 8), 0.05, 0.08, 0.0992, 
-                                         0.3, 0.15, 0.01, 0.3, 0.01, rep(NA, 3))]
+                                        0.3, 0.15, 0.01, 0.3, 0.01, rep(NA, 3), NA)]
 REco.params$diet[, Foragefish1     := c(rep(NA, 3), rep(c(1e-4, NA), 4), rep(NA, 7), 
-                                         0.8196, 0.06, 0.12, NA)]
+                                        0.8196, 0.06, 0.12, NA, NA)]
 REco.params$diet[, Foragefish2     := c(rep(NA, 3), rep(c(1e-4, NA), 4), rep(NA, 7), 
-                                         0.8196, 0.06, 0.12, NA)]
+                                        0.8196, 0.06, 0.12, NA, NA)]
 REco.params$diet[, OtherForagefish := c(rep(NA, 3), rep(c(1e-4, NA), 4), rep(NA, 7), 
-                                         0.8196, 0.06, 0.12, NA)]
+                                        0.8196, 0.06, 0.12, NA, NA)]
 REco.params$diet[, Megabenthos     := c(rep(NA, 15), 0.1, 0.03, 0.55, rep(NA, 2), 0.32,
-                                         NA)]
-REco.params$diet[, Shellfish       := c(rep(NA, 18), 0.3, 0.5, 0.2, NA)]
-REco.params$diet[, Macrobenthos    := c(rep(NA, 16), 0.01, rep(0.2, 2), NA, 0.59, NA)]
-REco.params$diet[, Zooplankton     := c(rep(NA, 18), 0.2, 0.6, 0.2, NA)]
+                                        NA, NA)]
+REco.params$diet[, Shellfish       := c(rep(NA, 18), 0.3, 0.5, 0.2, NA, NA)]
+REco.params$diet[, Macrobenthos    := c(rep(NA, 16), 0.01, rep(0.2, 2), NA, 0.59, NA, NA)]
+REco.params$diet[, Zooplankton     := c(rep(NA, 18), 0.2, 0.6, 0.2, NA, NA)]
 ```
 ```{r Dietfile Table, echo = F}
 knitr::kable(REco.params$diet, caption = 'Diet parameters for R Ecosystem')


### PR DESCRIPTION
The vignette previously issued a few warning messages, since the diet assignments were one element less in length than expected (due to introduction of the new import row).  While this didn't cause any computational issues (the default NA fill is appropriate here), this update eliminates the warnings.
